### PR TITLE
making port optional now that the dst port is in the token

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,7 +15,9 @@ limitations under the License.
 */
 package main
 
-import "github.com/mysocketio/mysocketctl-go/cmd"
+import (
+	"github.com/mysocketio/mysocketctl-go/cmd"
+)
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
JWT token now has an additional 'claim' called: 'socket_port'. 
If the user doesn't specify the port number, now optional, we'll use what we find in the claim.

this will make for a better user experience. The user doesn't need to know the dst port. Just the name of the socket.
happy user :) 

```go run main.go client tls --host dark-haze-8728.edge.mysocket.io -p 42202```
and
```go run main.go client tls --host dark-haze-8728.edge.mysocket.io```
are the same, 42202 is now in the token.

```
$ go run main.go client tls --host dark-haze-8728.edge.mysocket.io
SSH-2.0-OpenSSH_8.2p1 Ubuntu-4ubuntu0.1
```