### PR TITLE
adding support for short lived ssh certs

### DIFF
--- a/cmd/account.go
+++ b/cmd/account.go
@@ -36,12 +36,14 @@ var createCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a new account",
 	Run: func(cmd *cobra.Command, args []string) {
-		if _, err := os.Stat(sshkey); err == nil {
-			dat, err := ioutil.ReadFile(sshkey)
-			if err != nil {
-				log.Fatalf("Unable to read the file %s, please check file permissions and try again (%v)", sshkey, err)
+		if sshkey != "" {
+			if _, err := os.Stat(sshkey); err == nil {
+				dat, err := ioutil.ReadFile(sshkey)
+				if err != nil {
+					log.Fatalf("Unable to read the file %s, please check file permissions and try again (%v)", sshkey, err)
+				}
+				sshkey = string(dat)
 			}
-			sshkey = string(dat)
 		}
 
 		err := http.Register(name, email, password, sshkey)
@@ -95,7 +97,7 @@ func init() {
 	createCmd.MarkFlagRequired("email")
 	createCmd.MarkFlagRequired("name")
 	createCmd.MarkFlagRequired("password")
-	createCmd.MarkFlagRequired("sshkey")
+	createCmd.Flags().MarkHidden("sshkey")
 
 	accountCmd.AddCommand(createCmd)
 	accountCmd.AddCommand(showCmd)

--- a/internal/http/models.go
+++ b/internal/http/models.go
@@ -44,3 +44,8 @@ type Tunnel struct {
 	LocalPort    int    `json:"local_port,omitempty"`
 	TunnelServer string `json:"tunnel_server,omitempty"`
 }
+
+type SshCsr struct {
+	SSHPublicKey  string `json:"ssh_public_key"`
+	SSHSignedCert string `json:"signed_ssh_cert,omitempty"`
+}

--- a/internal/ssh/handler.go
+++ b/internal/ssh/handler.go
@@ -108,9 +108,20 @@ func getSshCert(userId string, socketID string, tunnelID string) (s ssh.Signer) 
 	if err != nil {
 		log.Fatalf("Error: %v", err)
 	}
-	err = client.Request("POST", "socket/"+socketID+"/tunnel/"+tunnelID+"/signkey", &signedCert, newCsr)
-	if err != nil {
-		log.Fatalf(fmt.Sprintf("Error: %v", err))
+	//err = client.Request("POST", "socket/"+socketID+"/tunnel/"+tunnelID+"/signkey", &signedCert, newCsr)
+
+	for i := 1; i <= 10; i++ {
+		err = client.Request("POST", "socket/"+socketID+"/tunnel/"+tunnelID+"/signkey", &signedCert, newCsr)
+		if err == nil {
+			break
+		}
+		log.Println(fmt.Sprintf("Unable to get signed cert from API, will try again in %d seconds. Attempt %d of 10", 2*i, i))
+
+		d := time.Duration(2*i) * time.Second
+		time.Sleep(d)
+	}
+	if signedCert.SSHSignedCert == "" {
+		log.Fatalf("Error: Unable to get signed key from Server")
 	}
 
 	certData := []byte(signedCert.SSHSignedCert)


### PR DESCRIPTION
This PR adds support for the client to fetch a short lived ssh cert when
setting up a tunnel from an origin.

The idea is that this replaces the need for users to ship around the
private key between nodes.

Work flow:
1) check if a private key exists on the node, if not one is generated
and stored in the user home dir ~/.mysocket/USERID, ie: .mysocket/user_add566c8cb8d4ce5828ea8fe09741123
2) before setting up ssh tunnel session, use the mysocket API to do a
key signing request. ie. post public key to /socket/{socket_id}/tunnel/{tunnel_id}/signkey
3) this returns a signed cert, which is turned into a Go certSigner
object and added to the list of signers (public private key pairs to use
for auth).

Since these are short lived certs (5min), by just having access to the
private key, no real access can be gained. A CSR (cert signing request)
is always needed and for that the users credentials are needed.

the server adds the tunnel_id as a principle field to the signed cert.

Server side has been upgraded as well to accept tunnels authenticating
with certs.