### PR TITLE
added GOARCH option to GetLatestBinary function

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -72,7 +72,7 @@ var upgradeVersionCmd = &cobra.Command{
 			return
 		}
 
-		checksum, latest, err := http.GetLatestBinary(runtime.GOOS)
+		checksum, latest, err := http.GetLatestBinary(runtime.GOOS, runtime.GOARCH)
 		if latest == nil {
 			log.Fatalf("Error while downloading latest version %v", err)
 		}

--- a/internal/http/handler.go
+++ b/internal/http/handler.go
@@ -172,7 +172,7 @@ func GetLatestVersion() (string, error) {
 	return version, nil
 }
 
-func GetLatestBinary(osname string) (string, []byte, error) {
+func GetLatestBinary(osname string, osarch string) (string, []byte, error) {
 	var bin_url string
 	var checksum_url string
 	switch osname {
@@ -180,8 +180,13 @@ func GetLatestBinary(osname string) (string, []byte, error) {
 		bin_url = download_url + "/darwin_amd64/mysocketctl"
 		checksum_url = download_url + "/darwin_amd64/sha256-checksum.txt"
 	case "linux":
+            if osarch == arm64 {
+                bin_url = download_url + "/linux_arm64/mysocketctl"
+		checksum_url = download_url + "/linux_arm64/sha256-checksum.txt"
+            } else {
 		bin_url = download_url + "/linux_amd64/mysocketctl"
 		checksum_url = download_url + "/linux_amd64/sha256-checksum.txt"
+            }
 	case "windows":
 		bin_url = download_url + "/windows_amd64/mysocketctl.exe"
 		checksum_url = download_url + "/windows_amd64/sha256-checksum.txt"

--- a/internal/http/handler.go
+++ b/internal/http/handler.go
@@ -180,7 +180,7 @@ func GetLatestBinary(osname string, osarch string) (string, []byte, error) {
 		bin_url = download_url + "/darwin_amd64/mysocketctl"
 		checksum_url = download_url + "/darwin_amd64/sha256-checksum.txt"
 	case "linux":
-            if osarch == arm64 {
+            if osarch == "arm64" {
                 bin_url = download_url + "/linux_arm64/mysocketctl"
 		checksum_url = download_url + "/linux_arm64/sha256-checksum.txt"
             } else {


### PR DESCRIPTION
Added runtime.GOARCH in GetLatestBinary call as well as the function itself with an if statement within the linux case to check for arm64 and use appropriate url instead.