### PR TITLE
completion: new subcommend to generate shell completion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,4 @@
 # vendor/
 bin/
 mysocketctl
-
+mysocketctl-go

--- a/README.md
+++ b/README.md
@@ -8,7 +8,14 @@ Please check the full documentation here: [mysocketctl documentation on readthed
 
 Installation
 --------------------
-Please download the binaries at https://download.edge.mysocket.io 
+Please download the binaries at https://download.edge.mysocket.io
+
+Shell auto-completion
+--------------------
+display autocomplete installation instructions
+```shell
+mysocketctl completion --help
+```
 
 Authors
 --------------------

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,0 +1,88 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var completionCmd = &cobra.Command{
+	Use:                   "completion [bash|zsh|fish|powershell]",
+	Short:                 "Generate completion script",
+	Long:                  completionUsage(),
+	DisableFlagsInUseLine: true,
+	ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+	Args:                  cobra.ExactValidArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		switch args[0] {
+		case "bash":
+			cmd.Root().GenBashCompletion(os.Stdout)
+		case "zsh":
+			cmd.Root().GenZshCompletion(os.Stdout)
+		case "fish":
+			cmd.Root().GenFishCompletion(os.Stdout, true)
+		case "powershell":
+			cmd.Root().GenPowerShellCompletion(os.Stdout)
+		}
+	},
+}
+
+func completionUsage() string {
+	brewPrefix := "/usr/local"
+	if runtime.GOOS == "darwin" {
+		out, err := exec.Command("brew", "--prefix").CombinedOutput()
+		trimmed := strings.TrimSpace(string(out))
+		if err != nil {
+			fmt.Printf("ERROR: cannot execute `brew --prefix` %s, %s\n\n", trimmed, err)
+		} else {
+			brewPrefix = trimmed
+		}
+	}
+	return `To load completions:
+
+Bash:
+
+  $ source <(mysocketctl completion bash)
+
+  # To load completions for each session, execute once:
+  # Linux:
+  $ mysocketctl completion bash > /etc/bash_completion.d/mysocketctl
+  # macOS:
+  $ mysocketctl completion bash > ` + brewPrefix + `/etc/bash_completion.d/mysocketctl
+
+Zsh:
+
+  # If shell completion is not already enabled in your environment,
+  # you will need to enable it.  You can execute the following once:
+
+  $ echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+  # To load completions for each session, execute once:
+  $ mysocketctl completion zsh > "${fpath[1]}/_mysocketctl"
+
+  # You will need to start a new shell for this setup to take effect.
+
+fish:
+
+  $ mysocketctl completion fish | source
+
+  # To load completions for each session, execute once:
+  $ mysocketctl completion fish > ~/.config/fish/completions/mysocketctl.fish
+
+PowerShell:
+
+  PS> mysocketctl completion powershell | Out-String | Invoke-Expression
+
+  # To load completions for every new session, run:
+  PS> mysocketctl completion powershell > mysocketctl.ps1
+  # and source this file from your PowerShell profile.
+`
+}
+
+func init() {
+	rootCmd.AddCommand(completionCmd)
+}


### PR DESCRIPTION
- add new subcommend for generating shell completions
- supports bash, zsh, fish and powershell
- `mysocketctl completion --help` for instructions

<img width="1109" alt="Screen Shot 2021-12-08 at 2 00 24 PM" src="https://user-images.githubusercontent.com/965430/145291373-5676ca12-4c90-4ec8-afff-49ea10940b97.png">