### PR TITLE
ME-186: new s3 bucket for mysocketctl CLI tool in prod

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,8 +8,8 @@ jobs:
   build-ubuntu:
     runs-on: ubuntu-latest
     env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.S3_AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_AWS_SECRET_ACCESS_KEY }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.PROD_S3_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.PROD_S3_AWS_SECRET_ACCESS_KEY }}
 
     steps:
       - uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ GOCLEAN=$(GOCMD) clean
 GOTEST=$(GOCMD) test
 GOGET=$(GOCMD) get
 BINARY_NAME=mysocketctl
-BUCKET=mysocketctl
+BUCKET=pub-mysocketctl-bin
 
 DATE := $(shell git log -1 --format=%cd --date=format:"%Y%m%d")
 VERSION := $(shell git describe --long --dirty --tags)


### PR DESCRIPTION
mysocketctl is being moved to pub-mysocketctl-bin in (235487987553)prod account
using new github-actions user in prod account with s3 access arn:aws:iam::235487987553:user/github-actions
new action secrets credentials
- PROD_S3_AWS_ACCESS_KEY_ID
- PROD_S3_AWS_SECRET_ACCESS_KEY
have been added to mysocketio/mysocketctl-go repo -> https://github.com/mysocketio/mysocketctl-go/settings/secrets/actions