### PR TITLE
dbeaver invocation syntax in windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,14 @@ build:
 build-linux:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) $(FLAGS) -o $(BINARY_NAME) -v
 
+build-all:
+	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build $(FLAGS) -o $(BINARY_NAME)_windows_amd64
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build $(FLAGS) -o $(BINARY_NAME)_linux_amd64
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build $(FLAGS) -o $(BINARY_NAME)_linux_arm64
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm go build $(FLAGS) -o $(BINARY_NAME)_linux_arm
+	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build $(FLAGS)  -o $(BINARY_NAME)_darwin_amd64
+	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build $(FLAGS)  -o $(BINARY_NAME)_darwin_arm64
+
 lint:
 	@echo "running go fmt"
 	$(GOFMT) -w .

--- a/cmd/client/db/dbeaver.go
+++ b/cmd/client/db/dbeaver.go
@@ -72,7 +72,8 @@ var dbeaverCmd = &cobra.Command{
 		case "darwin":
 			return client.ExecCommand("open", "-a", "dbeaver", "--args", "-con", conn)
 		case "windows":
-			return client.ExecCommand("cmd", "/C", "start", "", "dbeaver.exe", "-con", conn)
+			conn = "\"" + conn + "\""
+			return client.ExecCommand("cmd", "/C", "start", "", "c:\\Program Files\\DBeaver\\dbeaver.exe", "-con", conn)
 		default:
 			return client.ExecCommand("dbeaver", "-con", conn)
 		}


### PR DESCRIPTION
the -con section requires to be explicitly quoted
windows needs explicit path to dbeaver.exe binary