### PR TITLE
send client version + requested with (mysocketctl)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 bin/
 mysocketctl
 mysocketctl-go
+*.swp

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -144,7 +144,7 @@ var connectCmd = &cobra.Command{
 		}
 
 		c := http.Socket{}
-		err = client.Request("POST", "connect", &c, connection)
+		err = client.WithVersion(version).Request("POST", "connect", &c, connection)
 		if err != nil {
 			log.Fatalf(fmt.Sprintf("Error: %v", err))
 		}

--- a/cmd/socket.go
+++ b/cmd/socket.go
@@ -179,7 +179,7 @@ var socketCreateCmd = &cobra.Command{
 			UpstreamHttpHostname:  upstream_http_hostname,
 			UpstreamType:          upstreamType,
 		}
-		err = client.Request("POST", "socket", &s, newSocket)
+		err = client.WithVersion(version).Request("POST", "socket", &s, newSocket)
 		if err != nil {
 			log.Fatalf(fmt.Sprintf("Error: %v", err))
 		}

--- a/internal/http/handler.go
+++ b/internal/http/handler.go
@@ -26,7 +26,8 @@ type ErrorMessage struct {
 }
 
 type Client struct {
-	token string
+	token   string
+	version string
 }
 
 func APIURL() string {
@@ -73,12 +74,26 @@ func NewClient() (*Client, error) {
 	return c, nil
 }
 
+func (c *Client) WithVersion(version string) *Client {
+	if version == "" {
+		return c
+	}
+	c2 := new(Client)
+	*c2 = *c
+	c2.version = version
+	return c2
+}
+
 func (c *Client) Request(method string, url string, target interface{}, data interface{}) error {
 	jv, _ := json.Marshal(data)
 	body := bytes.NewBuffer(jv)
 
 	req, _ := h.NewRequest(method, fmt.Sprintf("%s/%s", apiUrl(), url), body)
 	req.Header.Add("x-access-token", c.token)
+	req.Header.Add("x-client-requested-with", "mysocketctl")
+	if c.version != "" {
+		req.Header.Add("x-client-version", c.version)
+	}
 	req.Header.Set("Content-Type", "application/json")
 	client := &h.Client{}
 	resp, err := client.Do(req)


### PR DESCRIPTION
Send 2 new custom headers when making requests to the api:

- `x-client-version`: send a version that follows the same pattern of `v1.0-124-g725cc5c`
- `x-client-requested-with`: send `mysocketctl` from the cli app