### PR TITLE
do not print io copy errors

### DIFF
--- a/internal/ssh/handler.go
+++ b/internal/ssh/handler.go
@@ -384,19 +384,13 @@ func handleClient(client net.Conn, remote net.Conn) {
 
 	// Start remote -> local data transfer
 	go func() {
-		_, err := io.Copy(client, remote)
-		if err != nil {
-			log.Printf("error while copy remote->local: %s\n", err)
-		}
+		io.Copy(client, remote)
 		chDone <- true
 	}()
 
 	// Start local -> remote data transfer
 	go func() {
-		_, err := io.Copy(remote, client)
-		if err != nil {
-			log.Printf("error while copy local->remote: %s\n", err)
-		}
+		io.Copy(remote, client)
 		chDone <- true
 	}()
 


### PR DESCRIPTION
This will remove the following logging:
2022/07/05 11:35:17 error while copy remote->local: read tcp 127.0.0.1:60389->127.0.0.1:10006: use of closed network connection