### PR TITLE
FEAT: adding --login/-l flag to client ssh command

### DIFF
--- a/cmd/client/ssh/ssh.go
+++ b/cmd/client/ssh/ssh.go
@@ -55,8 +55,6 @@ var sshCmd = &cobra.Command{
 			sshLoginName = os.Getenv("USER")
 			if sshLoginName == "" {
 				return errors.New("falied to get login/username, empty login not allowed")
-			} else {
-				fmt.Printf("No login or username argument specified, using current user: %s\n", sshLoginName)
 			}
 		}
 


### PR DESCRIPTION
This brings mysocketctl client ssh -l $user in line with ssh -l $user behaviour

We are also adding support for defaulting to OS $user variable if no user/login parameter is supplied further mimicking open SSH client behaviour

Finally adding the user/login to target server output
```
~:$ ./mysocketctl client ssh ssh-socket-name 

Connecting to Server: ssh-socket-name:28602 as os-current-user