### PR TITLE
Improve reliability for static sockets

### DIFF
--- a/internal/connector/discover/static_sockets.go
+++ b/internal/connector/discover/static_sockets.go
@@ -14,10 +14,11 @@ type StaticSocketFinder struct{}
 var _ Discover = (*StaticSocketFinder)(nil)
 
 func (s *StaticSocketFinder) SkipRun(ctx context.Context, cfg config.Config, state DiscoverState) bool {
-	return state.RunsCount > 1 || state.RunsCount == 1
+	return false
 }
 
 func (s *StaticSocketFinder) Find(ctx context.Context, cfg config.Config, state DiscoverState) ([]models.Socket, error) {
+	time.Sleep(30 * time.Second)
 	sockets := []models.Socket{}
 
 	time.Sleep(5 * time.Second)

--- a/internal/connector/discover/static_sockets.go
+++ b/internal/connector/discover/static_sockets.go
@@ -19,10 +19,8 @@ func (s *StaticSocketFinder) SkipRun(ctx context.Context, cfg config.Config, sta
 
 func (s *StaticSocketFinder) Find(ctx context.Context, cfg config.Config, state DiscoverState) ([]models.Socket, error) {
 	time.Sleep(30 * time.Second)
+
 	sockets := []models.Socket{}
-
-	time.Sleep(5 * time.Second)
-
 	for _, socketMap := range cfg.Sockets {
 		socket := models.Socket{}
 

--- a/internal/ssh/handler.go
+++ b/internal/ssh/handler.go
@@ -55,7 +55,7 @@ func sshServer() string {
 	}
 }
 
-func getSshCert(userId string, socketID string, tunnelID string, accessToken string) (s ssh.Signer, err error) {
+func getSshCert(userId string, socketID string, tunnelID string, accessToken string, numOfRetry int) (s ssh.Signer, err error) {
 
 	// First check if we already have a mysocket key pair
 
@@ -135,7 +135,7 @@ func getSshCert(userId string, socketID string, tunnelID string, accessToken str
 	}
 	//err = client.Request("POST", "socket/"+socketID+"/tunnel/"+tunnelID+"/signkey", &signedCert, newCsr)
 
-	for i := 1; i <= 10; i++ {
+	for i := 1; i <= numOfRetry; i++ {
 		err = client.Request("POST", "socket/"+socketID+"/tunnel/"+tunnelID+"/signkey", &signedCert, newCsr)
 		if err == nil {
 			break
@@ -239,7 +239,7 @@ func SshConnect(userID string, socketID string, tunnelID string, port int, targe
 		// We'll use that to authenticate. This returns a signer object.
 		// for now we'll just add it to the signers list.
 		// In future, this is the only auth method we should use.
-		sshCert, err := getSshCert(userID, socketID, tunnelID, accessToken)
+		sshCert, err := getSshCert(userID, socketID, tunnelID, accessToken, 10)
 		if err != nil {
 			return ErrFailedToGetSshCert
 		}


### PR DESCRIPTION
# Summary
- check for new static sockets every 30 seconds
- improve the retry and try to fetch the cert again
- improve how to handle errors and try to identify which is error that we should abort retries