### PR TITLE
fix: use border0

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -211,7 +211,7 @@ var clientLoginStatusCmd = &cobra.Command{
 		valid, _, email, err := client.IsExistingClientTokenValid("")
 		if !valid {
 			fmt.Println(err)
-			fmt.Println("Please login again: mysocketctl client login")
+			fmt.Println("Please login again: border0 client login")
 		} else {
 			fmt.Println("Token Valid, logged in as " + email)
 		}
@@ -246,7 +246,7 @@ var clientDnsUpdaterCmd = &cobra.Command{
 // clientServiceCmd represents the client service command
 var clientServiceCmd = &cobra.Command{
 	Use:   "service",
-	Short: "Install, Remove, Start and Stop the mysocketctl client service",
+	Short: "Install, Remove, Start and Stop the border0 client service",
 
 	Run: func(cmd *cobra.Command, args []string) {
 

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -22,7 +22,7 @@ var completionCmd = &cobra.Command{
 		case "bash":
 			cmd.Root().GenBashCompletion(os.Stdout)
 		case "zsh":
-			zshHead := "#compdef mysocketctl\ncompdef _mysocketctl mysocketctl\n"
+			zshHead := "#compdef border0\ncompdef _border0 border0\n"
 			os.Stdout.Write([]byte(zshHead))
 
 			cmd.Root().GenZshCompletion(os.Stdout)
@@ -49,13 +49,13 @@ func completionUsage() string {
 
 Bash:
 
-  $ source <(mysocketctl completion bash)
+  $ source <(border0 completion bash)
 
   # To load completions for each session, execute once:
   # Linux:
-  $ mysocketctl completion bash > /etc/bash_completion.d/mysocketctl
+  $ border0 completion bash > /etc/bash_completion.d/border0
   # macOS:
-  $ mysocketctl completion bash > ` + brewPrefix + `/etc/bash_completion.d/mysocketctl
+  $ border0 completion bash > ` + brewPrefix + `/etc/bash_completion.d/border0
 
 Zsh:
 
@@ -65,23 +65,23 @@ Zsh:
   $ echo "autoload -U compinit; compinit" >> ~/.zshrc
 
   # To load completions for each session, execute once:
-  $ mysocketctl completion zsh > "${fpath[1]}/_mysocketctl"
+  $ border0 completion zsh > "${fpath[1]}/_border0"
 
   # You will need to start a new shell for this setup to take effect.
 
 fish:
 
-  $ mysocketctl completion fish | source
+  $ border0 completion fish | source
 
   # To load completions for each session, execute once:
-  $ mysocketctl completion fish > ~/.config/fish/completions/mysocketctl.fish
+  $ border0 completion fish > ~/.config/fish/completions/border0.fish
 
 PowerShell:
 
-  PS> mysocketctl completion powershell | Out-String | Invoke-Expression
+  PS> border0 completion powershell | Out-String | Invoke-Expression
 
   # To load completions for every new session, run:
-  PS> mysocketctl completion powershell > mysocketctl.ps1
+  PS> border0 completion powershell > border0.ps1
   # and source this file from your PowerShell profile.
 `
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -69,8 +69,8 @@ var (
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:     "mysocketctl",
-	Short:   "mysocket.io command line interface (CLI)",
+	Use:     "border0",
+	Short:   "border0 command line interface (CLI)",
 	Version: version,
 }
 
@@ -84,7 +84,7 @@ func Execute() {
 }
 
 func init() {
-	rootCmd.SetVersionTemplate(fmt.Sprintf("mysocketctl:\nversion %s\ndate: %s\n", version, date))
+	rootCmd.SetVersionTemplate(fmt.Sprintf("border0:\nversion %s\ndate: %s\n", version, date))
 }
 
 func splitLongLines(b string, maxLength int) string {


### PR DESCRIPTION
autocompletion fix

you do need to generate the autocomplete file again.
`` border0 completion zsh > "${fpath[1]}/_border0" ``